### PR TITLE
Handle errors

### DIFF
--- a/packages/sdk-server/src/lib/chains/algorand/poller.algorand.ts
+++ b/packages/sdk-server/src/lib/chains/algorand/poller.algorand.ts
@@ -108,7 +108,7 @@ export class GlitterAlgorandPoller implements GlitterPoller {
                         break;
                     default:
                         throw ServerError.InvalidBridgeType(
-                            BridgeNetworks.solana,
+                            BridgeNetworks.algorand,
                             cursor.bridgeType
                         );
                 }

--- a/packages/sdk-server/src/lib/chains/algorand/poller.algorand.ts
+++ b/packages/sdk-server/src/lib/chains/algorand/poller.algorand.ts
@@ -90,28 +90,32 @@ export class GlitterAlgorandPoller implements GlitterPoller {
         //Get partial transactions
         const partialTxns: PartialBridgeTxn[] = [];
         for (const txnID of signatures) {
-            //Ensure Transaction Exists
-            if (!txnID) continue;
-
-            //Process Transaction
-            let partialTxn: PartialBridgeTxn | undefined;
-            switch (cursor.bridgeType) {
-                case BridgeType.TokenV1:
-                    partialTxn = await AlgorandTokenV1Parser.process(sdkServer, txnID, client, indexer);
-                    break;
-                case BridgeType.TokenV2:
-                    partialTxn = await AlgorandTokenV2Parser.process(sdkServer, txnID, client, indexer, cursor);
-                    break;
-                case BridgeType.USDC:
-                    partialTxn = await AlgorandUSDCParser.process(sdkServer, txnID, client, indexer, cursor);
-                    break;
-                default:
-                    throw ServerError.InvalidBridgeType(
-                        BridgeNetworks.solana,
-                        cursor.bridgeType
-                    );
+            try {
+                //Ensure Transaction Exists
+                if (!txnID) continue;
+    
+                //Process Transaction
+                let partialTxn: PartialBridgeTxn | undefined;
+                switch (cursor.bridgeType) {
+                    case BridgeType.TokenV1:
+                        partialTxn = await AlgorandTokenV1Parser.process(sdkServer, txnID, client, indexer);
+                        break;
+                    case BridgeType.TokenV2:
+                        partialTxn = await AlgorandTokenV2Parser.process(sdkServer, txnID, client, indexer, cursor);
+                        break;
+                    case BridgeType.USDC:
+                        partialTxn = await AlgorandUSDCParser.process(sdkServer, txnID, client, indexer, cursor);
+                        break;
+                    default:
+                        throw ServerError.InvalidBridgeType(
+                            BridgeNetworks.solana,
+                            cursor.bridgeType
+                        );
+                }
+                if (CursorFilter(cursor, partialTxn)) partialTxns.push(partialTxn);                
+            } catch (error) {
+                console.error((error as Error).message)
             }
-            if (CursorFilter(cursor, partialTxn)) partialTxns.push(partialTxn);
         }
 
         //update cursor

--- a/packages/sdk-server/src/lib/chains/solana/poller.solana.ts
+++ b/packages/sdk-server/src/lib/chains/solana/poller.solana.ts
@@ -129,33 +129,37 @@ export class GlitterSolanaPoller implements GlitterPoller {
         //Get partial transactions
         const partialTxns: PartialBridgeTxn[] = [];
         for (const txn of txnData) {
-            //Ensure Transaction Exists
-            if (!txn) continue;
+            try {            
+                //Ensure Transaction Exists
+                if (!txn) continue;
 
-            //Process Transaction
-            let partialTxn: PartialBridgeTxn | undefined;
-            switch (cursor.bridgeType) {
-                case BridgeType.TokenV1:
-                    partialTxn = await SolanaV1Parser.process(sdkServer, txn);
-                    break;
-                case BridgeType.TokenV2:
-                    partialTxn = await SolanaV2Parser.process(sdkServer, client, txn);
-                    break;
-                case BridgeType.USDC:
-                    partialTxn = await SolanaUSDCParser.process(
-                        sdkServer,
-                        txn,
-                        client,
-                        cursor
-                    );
-                    break;
-                default:
-                    throw ServerError.InvalidBridgeType(
-                        BridgeNetworks.solana,
-                        cursor.bridgeType
-                    );
+                //Process Transaction
+                let partialTxn: PartialBridgeTxn | undefined;
+                switch (cursor.bridgeType) {
+                    case BridgeType.TokenV1:
+                        partialTxn = await SolanaV1Parser.process(sdkServer, txn);
+                        break;
+                    case BridgeType.TokenV2:
+                        partialTxn = await SolanaV2Parser.process(sdkServer, client, txn);
+                        break;
+                    case BridgeType.USDC:
+                        partialTxn = await SolanaUSDCParser.process(
+                            sdkServer,
+                            txn,
+                            client,
+                            cursor
+                        );
+                        break;
+                    default:
+                        throw ServerError.InvalidBridgeType(
+                            BridgeNetworks.solana,
+                            cursor.bridgeType
+                        );
+                }
+                if (CursorFilter(cursor, partialTxn)) partialTxns.push(partialTxn);
+            } catch (error) {
+                console.error((error as Error).message)
             }
-            if (CursorFilter(cursor, partialTxn)) partialTxns.push(partialTxn);
         }
 
         //update cursor


### PR DESCRIPTION
We have an issue when the poller processes a batch of transactions, if a single tx fails to process the whole batch fails and the cursor will never advance.
I've wrapped the processing of txs inside a try/catch to ensure the cursor can continue to advance if one of the tx has unexpected properties.

ServerError.InvalidBridgeType is also wrong for the evm poller, we can fix this in another pr.